### PR TITLE
2024/OSFC/enabling_coreboot_on_talosII: add workaround for 2nd level list item

### DIFF
--- a/2024/OSFC/enabling_coreboot_on_talosII.html
+++ b/2024/OSFC/enabling_coreboot_on_talosII.html
@@ -23,6 +23,10 @@
         vertical-align: super;
         font-size: smaller;
       }
+      .force-2l-list ul ul{
+          list-style-type: circle;
+          margin-left: 1em;
+      }
     </style>
   </head>
   <body>

--- a/2024/OSFC/enabling_coreboot_on_talosII.md
+++ b/2024/OSFC/enabling_coreboot_on_talosII.md
@@ -797,37 +797,40 @@ Next slide shows how those values were obtained.
 
 - QEMU monitor
   + but QEMU is nowhere close to real hardware
---
 
+--
 - BMC `pdbg`: https://github.com/open-power/pdbg
 <!-- Options must not be indented, it breaks rendering ¯\_(ツ)_/¯ -->
 .small-code[
-    ```
-Options:
-            -p, --processor=processor-id
-            -c, --chip=chiplet-id
-            -t, --thread=thread
-            -a, --all
-                    Run command on all possible processors/chips/threads (default)
-    Commands:
-            getscom <address>
-            putscom <address> <value> [<mask>]
-            getmem <address> <count>
-            putmem <address>
-            getvmem <virtual address>
-            getgpr <gpr>
-            putgpr <gpr> <value>
-            getnia
-            putnia <value>
-            getspr <spr>
-            putspr <spr> <value>
-            start
-            stop
-            threadstatus
-    ```
-]
 
+  ```text
+    Options:
+                -p, --processor=processor-id
+                -c, --chip=chiplet-id
+                -t, --thread=thread
+                -a, --all
+                        Run command on all possible processors/chips/threads (default)
+        Commands:
+                getscom <address>
+                putscom <address> <value> [<mask>]
+                getmem <address> <count>
+                putmem <address>
+                getvmem <virtual address>
+                getgpr <gpr>
+                putgpr <gpr> <value>
+                getnia
+                putnia <value>
+                getspr <spr>
+                putspr <spr> <value>
+                start
+                stop
+                threadstatus
+  ```
+
+]
+.force-2l-list[
 - supposedly works with GDB, haven't tried
+]
 
 ???
 
@@ -1093,11 +1096,9 @@ closer to the math presented in Hostboot's comments.
 <!-- Empty to keep the formatting -->
 
 --
+.force-2l-list[
 - except sometimes intermediate values exceed `float` precision
-
-???
-
-<!-- Empty to keep the formatting -->
+]
 
 --
 - Hostboot has an interesting approach to rounding:


### PR DESCRIPTION
Workaround pre-commit markdown lint problems of 2nd level list items preceded with remark formatting syntaxes.